### PR TITLE
fix dlurl

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,8 +29,9 @@ exports.GetLink = async (u) => {
     const url = _url.parse($('.flagen').attr('href'), true)
     const urlori = _url.parse(u)
     const key = url.query['key']
-    const time = parseInt(/var a = ([0-9]+);$/gm.exec($('#dlbutton').next().html())[1])
-    const dlurl = urlori.protocol + '//' + urlori.hostname + '/d/' + key + '/' + (Math.floor(time / 3) + time) + '/DOWNLOAD'
+    const time = eval($('#dlbutton').next().html().match(/\(([0-9%+\s]+)\)/m)[0].replace(/\(?\)?/gm, ""))
+    const fileName = $('#dlbutton').next().html().match(/.+"\/(.+)";$/m)[0].split(' + "/')[1].replace('";',"")
+    const dlurl = urlori.protocol + '//' + urlori.hostname + '/d/' + key + '/' + time + '/' + fileName
     console.log('✅  ' + _colors.green('Done'))
     return dlurl
 }


### PR DESCRIPTION
As known, zippyshare url "encrypting" method is changing so that's why I wanted to fix this after the last update. 

**The error:** 
```bash
(node:14401) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '1' of null
    at Object.exports.GetLink (/usr/local/lib/node_modules/zippydl/app.js:32:84)
```
which is this line: 
```js 
const time = parseInt(/var a = ([0-9]+);$/gm.exec($('#dlbutton').next().html())[1])
```

so I fixed that by grabbing the new time and filename and updated the dlurl
```js 
const time = eval($('#dlbutton').next().html().match(/\(([0-9%+\s]+)\)/m)[0].replace(/\(?\)?/gm, ""))
const fileName = $('#dlbutton').next().html().match(/.+"\/(.+)";$/m)[0].split(' + "/')[1].replace('";',"")
const dlurl = urlori.protocol + '//' + urlori.hostname + '/d/' + key + '/' + time + '/' + fileName
``` 

This code works but maybe needs some cleaning especially with regular expressions. 